### PR TITLE
Confirm attachinary require coffee-rails still.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,11 @@ source 'https://rubygems.org'
 # Likes:
 gem 'acts_as_votable', '~> 0.10.0'
 
-gem 'cloudinary', '1.1.7'
+gem 'cloudinary'
 gem 'attachinary', github: 'assembler/attachinary'
+# Need this until https://github.com/assembler/attachinary/pull/146 merged
+gem 'coffee-rails'
+
 gem 'jquery-fileupload-rails'
 gem "pundit"
 gem 'omniauth-facebook'
@@ -15,7 +18,6 @@ gem 'figaro'
 gem 'jbuilder', '~> 2.0'
 gem 'devise'
 gem 'redis'
-gem 'coffee-rails'
 
 gem "gmaps4rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
     tilt (2.0.7)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    uglifier (3.1.11)
+    uglifier (3.1.12)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -249,7 +249,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
-  cloudinary (= 1.1.7)
+  cloudinary
   coffee-rails
   devise
   figaro


### PR DESCRIPTION
upstream [PR](https://github.com/assembler/attachinary/pull/146) proposed.